### PR TITLE
Add link for discord in FAQ page

### DIFF
--- a/src/faq.md
+++ b/src/faq.md
@@ -43,5 +43,5 @@ At the moment, Caido Desktop is considered experimental and does not perform as 
 There are 3 options available:
 
 - Go check out the [Common Errors](/reference/common_errors.md) page.
-- Join the Discord.
+- Join the [Discord](https://links.caido.io/www-discord).
 - Raise an issue on [Github](https://github.com/caido/caido) if it's a bug.


### PR DESCRIPTION
Hello! I've added this part because it was missing a link.

![](https://github.com/user-attachments/assets/3de33297-3636-4fcb-976c-27dce319e42f)
